### PR TITLE
Patch deprecated references for active support

### DIFF
--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -53,7 +53,7 @@ module Packwerk
           if entries_for_file["violations"].all? { |type| new_entries_violation_types.include?(type) }
             stale_violations =
               entries_for_file["files"] - Array(@new_entries.dig(package, constant_name, "files"))
-            stale_violations.present?
+            stale_violations.any?
           else
             return true
           end

--- a/lib/packwerk/version.rb
+++ b/lib/packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Packwerk
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
## What are you trying to accomplish?

`Packwerk::DeprecatedReferences` relies on `Object#present?`, an ActiveSupport extension. This is causing Packwerk to break when using `bundle exec packwerk`.

## What approach did you choose and why?

Replace `#present?` with `#any?`. We could have tried requiring the core extension in the file, but the dependency itself seems unnecessary.

## What should reviewers focus on?


## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
